### PR TITLE
Fixed biome offset issue (rivers fix)

### DIFF
--- a/src/main/java/mcjty/lostcities/dimensions/world/lost/BiomeInfo.java
+++ b/src/main/java/mcjty/lostcities/dimensions/world/lost/BiomeInfo.java
@@ -23,7 +23,7 @@ public class BiomeInfo {
             BiomeInfo info = new BiomeInfo();
             int chunkX = coord.getChunkX();
             int chunkZ = coord.getChunkZ();
-            info.biomesForBiomeCheck = provider.worldObj.getBiomeProvider().getBiomesForGeneration(info.biomesForBiomeCheck, (chunkX - 1) * 4 - 2, chunkZ * 4 - 2, 10, 10);
+            info.biomesForBiomeCheck = provider.worldObj.getBiomeProvider().getBiomesForGeneration(info.biomesForBiomeCheck, chunkX * 4 - 2, chunkZ * 4 - 2, 10, 10);
             biomeInfoMap.put(coord, info);
         }
         return biomeInfoMap.get(coord);


### PR DESCRIPTION
Fixed an issue where all biomes would be offset by one chunk in the negative X direction. (This caused river biomes to spawn one chunk to the west of the actual water they were supposed to represent).